### PR TITLE
Streamed tarot readings with side-by-side comparisons

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -43,10 +43,38 @@ button:hover {
   text-align: left;
 }
 
+.cards {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.card {
+  text-align: center;
+}
+
+.card img {
+  width: 100px;
+  height: 180px;
+  object-fit: cover;
+  display: block;
+  margin: 0 auto 5px;
+}
+
 .interpretation {
   border-top: 1px solid #ddd;
   padding-top: 10px;
   margin-top: 10px;
+}
+
+.interpretations {
+  display: flex;
+  gap: 20px;
+}
+
+.interpretation {
+  flex: 1;
 }
 
 .rating button {

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const http = require('http');
 const fs = require('fs');
 const path = require('path');
+const url = require('url');
 const {deck, drawCards} = require('./tarot');
 
 const models = ['gpt-3.5-turbo', 'gpt-4o-mini'];
@@ -28,22 +29,25 @@ async function getInterpretation(model, question, cards) {
 }
 
 function handleReading(req, res) {
-  let body = '';
-  req.on('data', chunk => body += chunk);
-  req.on('end', async () => {
-    try {
-      const {question} = JSON.parse(body || '{}');
-      const cards = drawCards();
-      const interpretations = {};
-      for (const model of models) {
-        interpretations[model] = await getInterpretation(model, question, cards);
-      }
-      res.writeHead(200, {'Content-Type': 'application/json'});
-      res.end(JSON.stringify({cards, interpretations}));
-    } catch (err) {
-      res.writeHead(500, {'Content-Type': 'application/json'});
-      res.end(JSON.stringify({error: err.message}));
+  const {query} = url.parse(req.url, true);
+  const question = query.question || '';
+  const cards = drawCards();
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    'Connection': 'keep-alive'
+  });
+  res.write(`event: cards\ndata: ${JSON.stringify(cards)}\n\n`);
+  (async () => {
+    for (const model of models) {
+      const text = await getInterpretation(model, question, cards);
+      res.write(`event: interpretation\ndata: ${JSON.stringify({model, text})}\n\n`);
     }
+    res.write('event: end\ndata: done\n\n');
+    res.end();
+  })().catch(err => {
+    res.write(`event: error\ndata: ${JSON.stringify({error: err.message})}\n\n`);
+    res.end();
   });
 }
 
@@ -82,7 +86,7 @@ function serveStatic(filePath, res) {
 }
 
 const server = http.createServer((req, res) => {
-  if (req.method === 'POST' && req.url === '/reading') return handleReading(req, res);
+  if (req.method === 'GET' && req.url.startsWith('/reading')) return handleReading(req, res);
   if (req.method === 'POST' && req.url === '/rating') return handleRating(req, res);
   // serve static files
   if (req.method === 'GET') {


### PR DESCRIPTION
## Summary
- Serve tarot readings via Server-Sent Events, sending drawn cards first and each model's interpretation as it completes.
- Frontend uses an EventSource to render card images immediately and stream model interpretations.
- Flexbox layout displays model interpretations side-by-side for easier comparison and includes rating buttons.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a836f3bbe08331a8b60c80d2e45b6b