### PR TITLE
Improve interpretation streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple website for drawing tarot cards and comparing interpretations from mult
 ## Setup
 
 1. Install dependencies (none beyond Node.js).
-2. Set an `OPENAI_API_KEY` environment variable if you want live interpretations from OpenAI models.
+2. Set an `OPENROUTER_API_KEY` environment variable if you want live interpretations from OpenRouter models.
 
 ## Running
 


### PR DESCRIPTION
## Summary
- stream interpretations token-by-token using OpenRouter's streaming API
- update client to append streaming chunks and show rating controls when complete
- document `OPENROUTER_API_KEY` environment variable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a83a26db6883318568b8a2cf2e0ae7